### PR TITLE
Cinnamon support and huge fonts preventing

### DIFF
--- a/src/gnomehintssettings.cpp
+++ b/src/gnomehintssettings.cpp
@@ -258,8 +258,16 @@ void GnomeHintsSettings::loadFonts()
     qDeleteAll(m_fonts);
     m_fonts.clear();
 
+    // Qt 5.6 introduced new HiDPI support. It uses evironment settings to take DPI information
+    // and recalculates font and interface scaling. Adding 'text-scaling-factor' doubling
+    // scaling and fonts will be so huge.
+#if (QT_VERSION < QT_VERSION_CHECK(5, 6, 0))
     gdouble scaling = settingsGetDouble("text-scaling-factor");
     qCDebug(QGnomePlatform) << "Font scaling: " << scaling;
+#else
+    gdouble scaling = 1.0;
+    qCDebug(QGnomePlatform) << "Font scaling: forced to 1.0 (for Qt>=5.6)";
+#endif
 
     const QStringList fontTypes { "font-name", "monospace-font-name" };
 

--- a/src/gnomehintssettings.h
+++ b/src/gnomehintssettings.h
@@ -27,6 +27,7 @@
 #undef signals
 #include <gio/gio.h>
 #include <gtk-3.0/gtk/gtk.h>
+#include <gtk-3.0/gtk/gtksettings.h>
 #define signals Q_SIGNALS
 
 #include <qpa/qplatformtheme.h>
@@ -91,11 +92,21 @@ private:
     QStringList xdgIconThemePaths() const;
     QString kvantumThemeForGtkTheme() const;
     void configureKvantum(const QString &theme) const;
+    void configureSettingsSource();
+    void setupSettingsSignalHandling(GSettings *settings);
+
+    bool settingsHasKey(GSettings *settings, const gchar *key);
+    GSettings* selectSettingsSource(const gchar* key);
+
+    gdouble settingsGetDouble(const gchar* name, gdouble def = 0.0);
+    gchar* settingsGetString(const gchar* name, gchar *def = nullptr);
+    gint settingsGetInt(const gchar* name, gint def = 0);
 
     gboolean m_gtkThemeDarkVariant;
     gchar *m_gtkTheme;
     QPalette *m_palette;
     GSettings *m_settings;
+    GSettings *m_settingsFallback;
     QHash<QPlatformTheme::Font, QFont*> m_fonts;
     QHash<QPlatformTheme::ThemeHint, QVariant> m_hints;
 };


### PR DESCRIPTION
Cinnamon uses its own settings scheme and some settings from Gnome scheme. Allow to handle current desktop and switch between schemes.

Also, prevent huge fonts on Qt >= 5.6: Gnome after setting up font scaling configures system (xrandr, Xft.dpi and so on) and Qt take this information. Additional font scaling just doubling sizes and fonts look huge on displays with resolution about 144 DPI (all laptops with 15.6" and 1920x1080 for example).