### PR TITLE
Add support for settings portal

### DIFF
--- a/qgnomeplatform.pro
+++ b/qgnomeplatform.pro
@@ -7,6 +7,7 @@ CONFIG += plugin \
           link_pkgconfig
 
 QT += core-private \
+      dbus \
       gui-private \
       widgets
 


### PR DESCRIPTION
With this support, applications running in Flatpak/Snap will not need to have access to DConf, but will obtain configuration through the portal.