### PR TITLE
Prioritize Adwaita dark variant for all themes ending by "-dark"

### DIFF
--- a/common/gnomehintssettings.cpp
+++ b/common/gnomehintssettings.cpp
@@ -316,7 +316,7 @@ void GnomeHintsSettings::loadTheme()
     } else {
         qCDebug(QGnomePlatform) << "Theme name: " << m_gtkTheme;
 
-        if (m_gtkTheme.toLower() == QStringLiteral("adwaita-dark")) {
+        if (m_gtkTheme.toLower().endsWith("-dark")) {
             m_gtkThemeDarkVariant = true;
         }
 


### PR DESCRIPTION
This fixes dark support with Yura theme on last Ubuntu, and other dark themes.