### PR TITLE
Get rid of QtX11Extras

### DIFF
--- a/common/common.pro
+++ b/common/common.pro
@@ -8,7 +8,6 @@ CONFIG += c++11 \
 QT += core \
       dbus \
       theme_support-private \
-      x11extras \
       widgets
 
 PKGCONFIG += gtk+-3.0 \

--- a/common/gnomehintssettings.cpp
+++ b/common/gnomehintssettings.cpp
@@ -36,8 +36,6 @@
 #include <QDBusConnection>
 #include <QDBusMessage>
 
-#include <QX11Info>
-
 Q_LOGGING_CATEGORY(QGnomePlatform, "qt.qpa.qgnomeplatform")
 
 const QDBusArgument &operator>>(const QDBusArgument &argument, QMap<QString, QVariantMap> &map)
@@ -135,7 +133,7 @@ GnomeHintsSettings::GnomeHintsSettings()
                                               QStringLiteral("SettingChanged"), this, SLOT(portalSettingChanged(QString,QString,QDBusVariant)));
     }
 
-    if (!QX11Info::isPlatformX11())
+    if (QGuiApplication::platformName() != QStringLiteral("xcb"))
         cursorSizeChanged();
 
     loadFonts();
@@ -172,7 +170,7 @@ void GnomeHintsSettings::gsettingPropertyChanged(GSettings *settings, gchar *key
     } else if (changedProperty == QStringLiteral("monospace-font-name")) {
         gnomeHintsSettings->fontChanged();
     } else if (changedProperty == QStringLiteral("cursor-size")) {
-        if (!QX11Info::isPlatformX11())
+        if (QGuiApplication::platformName() != QStringLiteral("xcb"))
             gnomeHintsSettings->cursorSizeChanged();
     // Org.gnome.wm.preferences
     } else if (changedProperty == QStringLiteral("titlebar-font")) {

--- a/decoration/decoration.pro
+++ b/decoration/decoration.pro
@@ -12,8 +12,7 @@ CONFIG += plugin \
 QT += core \
       gui \
       waylandclient-private \
-      widgets \
-      x11extras
+      widgets
 
 LIBS += -lcommon
 

--- a/theme/qgnomeplatformtheme.cpp
+++ b/theme/qgnomeplatformtheme.cpp
@@ -23,8 +23,8 @@
 #include "qgtk3dialoghelpers.h"
 
 #include <QApplication>
+#include <QGuiApplication>
 #include <QStyleFactory>
-#include <QX11Info>
 
 #if !defined(QT_NO_DBUS) && !defined(QT_NO_SYSTEMTRAYICON)
 #include <private/qdbustrayicon_p.h>
@@ -32,7 +32,7 @@
 
 QGnomePlatformTheme::QGnomePlatformTheme()
 {
-    if (!QX11Info::isPlatformX11()) {
+    if (QGuiApplication::platformName() != QStringLiteral("xcb")) {
         if (!qEnvironmentVariableIsSet("QT_WAYLAND_DECORATION"))
             qputenv("QT_WAYLAND_DECORATION", "gnome");
     }

--- a/theme/theme.pro
+++ b/theme/theme.pro
@@ -13,7 +13,6 @@ QT += core-private \
       dbus \
       gui-private \
       theme_support-private \
-      x11extras \
       widgets
 
 LIBS += -lcommon


### PR DESCRIPTION
QX11Info::isPlatformX11 is just a thin wrapper that compares QGUiApplication::platformName: https://github.com/qt/qtx11extras/blob/c4b0571e2fd52581b6a84295f037fd74b89962f5/src/x11extras/qx11info_x11.cpp#L98-L101

I believe there is no need in an additional dependency for this simple check...