### PR TITLE
Prioritize Adwaita dark variant for all themes containing "-dark"

### DIFF
--- a/common/gnomehintssettings.cpp
+++ b/common/gnomehintssettings.cpp
@@ -306,7 +306,7 @@ void GnomeHintsSettings::loadTheme()
     } else {
         qCDebug(QGnomePlatform) << "Theme name: " << m_gtkTheme;
 
-        if (m_gtkTheme.toLower().endsWith("-dark")) {
+        if (m_gtkTheme.toLower().contains("-dark")) {
             m_gtkThemeDarkVariant = true;
         }
 


### PR DESCRIPTION
PR #52 already uses the dark variant for themes ending with "-dark", but
some themes has several dark theme variants and the word "dark" might
not show up at the very end.

e.g. for Materia, we have "Materia-dark" and "Materia-dark-compact".

Do a substring match instead to match more themes.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fedoraqt/qgnomeplatform/72)
<!-- Reviewable:end -->
