### PR TITLE
Implement switching themes for already running apps

### DIFF
--- a/src/common/gnomesettings.cpp
+++ b/src/common/gnomesettings.cpp
@@ -448,6 +448,15 @@ void GnomeSettingsPrivate::iconsChanged()
 void GnomeSettingsPrivate::themeChanged()
 {
     loadTheme();
+    auto app = qobject_cast<QApplication *>(QCoreApplication::instance());
+    if (app != nullptr) {
+        auto styleNames = qvariant_cast<QStringList>(m_hints[QPlatformTheme::StyleNames]);
+        for (auto style : styleNames) {
+            if (app->setStyle(style) != nullptr) {
+                break;
+            }
+        }
+    }
 }
 
 void GnomeSettingsPrivate::loadTitlebar()

--- a/src/common/gnomesettings.cpp
+++ b/src/common/gnomesettings.cpp
@@ -131,6 +131,10 @@ GnomeSettings::TitlebarButtonsPlacement GnomeSettings::titlebarButtonPlacement()
     return gnomeSettingsGlobal->titlebarButtonPlacement();
 }
 
+void GnomeSettings::setOnThemeChanged(std::function<void ()> callback) {
+    gnomeSettingsGlobal->setOnThemeChanged(callback);
+}
+
 static inline bool checkUsePortalSupport()
 {
     return !QStandardPaths::locate(QStandardPaths::RuntimeLocation, QStringLiteral("flatpak-info")).isEmpty() || qEnvironmentVariableIsSet("SNAP");
@@ -457,6 +461,10 @@ void GnomeSettingsPrivate::themeChanged()
             }
         }
     }
+
+    if (m_onThemeChanged != nullptr) {
+        m_onThemeChanged();
+    }
 }
 
 void GnomeSettingsPrivate::loadTitlebar()
@@ -759,6 +767,11 @@ void GnomeSettingsPrivate::configureKvantum(const QString &theme) const
     if (!config.contains("theme") || config.value("theme").toString() != theme) {
         config.setValue("theme", theme);
     }
+}
+
+void GnomeSettingsPrivate::setOnThemeChanged(std::function<void()> callback)
+{
+    m_onThemeChanged = callback;
 }
 
 template <typename T>

--- a/src/common/gnomesettings.h
+++ b/src/common/gnomesettings.h
@@ -58,6 +58,7 @@ public:
     static QString gtkTheme();
     static TitlebarButtons titlebarButtons();
     static TitlebarButtonsPlacement titlebarButtonPlacement();
+    static void setOnThemeChanged(std::function<void()> callback);
 };
 
 

--- a/src/common/gnomesettings_p.h
+++ b/src/common/gnomesettings_p.h
@@ -55,6 +55,7 @@ public:
     QVariant hint(QPlatformTheme::ThemeHint hint) const;
     TitlebarButtons titlebarButtons() const;
     TitlebarButtonsPlacement titlebarButtonPlacement() const;
+    void setOnThemeChanged(std::function<void()> callback);
 
 private Q_SLOTS:
     void cursorBlinkTimeChanged();
@@ -94,6 +95,7 @@ private:
     QMap<QString, QVariantMap> m_portalSettings;
     QPalette *m_palette = nullptr;
     QFont *m_fallbackFont = nullptr;
+    std::function<void()> m_onThemeChanged = nullptr;
 };
 
 #endif // GNOME_SETTINGS_P_H

--- a/src/decoration/qgnomeplatformdecoration.cpp
+++ b/src/decoration/qgnomeplatformdecoration.cpp
@@ -81,6 +81,15 @@ QGnomePlatformDecoration::QGnomePlatformDecoration()
     option.setWrapMode(QTextOption::NoWrap);
     m_windowTitle.setTextOption(option);
 
+    updateColors();
+
+    GnomeSettings::setOnThemeChanged([this]() {
+        this->updateColors();
+        this->update();
+    });
+}
+
+void QGnomePlatformDecoration::updateColors() {
     // Colors
     // TODO: move colors used for decorations to Adwaita-qt
     const bool darkVariant = GnomeSettings::isGtkThemeDarkVariant();

--- a/src/decoration/qgnomeplatformdecoration.h
+++ b/src/decoration/qgnomeplatformdecoration.h
@@ -72,6 +72,7 @@ private:
     void processMouseLeft(QWaylandInputDevice *inputDevice, const QPointF &local, Qt::MouseButtons b,Qt::KeyboardModifiers mods);
     void processMouseRight(QWaylandInputDevice *inputDevice, const QPointF &local, Qt::MouseButtons b,Qt::KeyboardModifiers mods);
     void renderButton(QPainter *painter, const QRectF &rect, Adwaita::ButtonType button, bool renderFrame, bool sunken);
+    void updateColors();
 
     bool clickButton(Qt::MouseButtons b, Button btn);
     bool doubleClickButton(Qt::MouseButtons b, const QPointF &local, const QDateTime &currentTime);


### PR DESCRIPTION
This PR makes it possible to update both the Qt theme and the decoration colors for already running apps, as described in #85.

I tested it with Speedcrunch and qBittorrent, which are respectively Qt5 and Qt6 applications.

https://user-images.githubusercontent.com/105007554/176576688-b431c9a2-743d-4a90-b55a-c57e2cc6789b.mp4

