### PR TITLE
Fix applying dark scheme when QT_STYLE_OVERRIDE is set

### DIFF
--- a/src/common/gnomesettings.cpp
+++ b/src/common/gnomesettings.cpp
@@ -213,9 +213,11 @@ bool GnomeSettings::canUseFileChooserPortal() const
 
 bool GnomeSettings::useGtkThemeDarkVariant() const
 {
-    const QString theme = m_hintProvider->gtkTheme();
-
-    if (m_hintProvider->canRelyOnAppearance()) {
+    QString theme = m_hintProvider->gtkTheme();
+    if (qEnvironmentVariableIsSet("QT_STYLE_OVERRIDE")) {
+        /* If QT_STYLE_OVERRIDE we should rely on it */
+        theme = QString::fromLocal8Bit(qgetenv("QT_STYLE_OVERRIDE"));
+    } else if (m_hintProvider->canRelyOnAppearance()) {
         return m_hintProvider->appearance() == PreferDark;
     }
 


### PR DESCRIPTION
When `QT_STYLE_OVERRIDE` is set to something like `Adwaita-dark` it breaks the theme since it doesn't apply the corresponding color scheme.
We should check if we should force dark color sheme similarly to how it's done in `GnomeSettings::styleNames()`.

P.S. it's fix for a regression that likely appeared in 28f14d370e5e7a6b9f68e90837ea58a60d9ef65b