### PR TITLE
Fix build without shadows enabled

### DIFF
--- a/src/decoration/qgnomeplatformdecoration.cpp
+++ b/src/decoration/qgnomeplatformdecoration.cpp
@@ -64,7 +64,11 @@
 #define BUTTON_WIDTH 28
 
 // Decoration sizing
+#ifdef DECORATION_SHADOWS_SUPPORT // Qt 6.2.0+ or patched QtWayland
 #define SHADOWS_WIDTH 10
+#else
+#define SHADOWS_WIDTH 0
+#endif
 #define TITLEBAR_HEIGHT 37
 #define WINDOW_BORDER_WIDTH 1
 
@@ -141,7 +145,6 @@ QRectF QGnomePlatformDecoration::minimizeButtonRect() const
     }
 }
 
-#ifdef DECORATION_SHADOWS_SUPPORT // Qt 6.2.0+ or patched QtWayland
 QMargins QGnomePlatformDecoration::margins(MarginsType marginsType) const
 {
     const bool maximized = waylandWindow()->windowStates() & Qt::WindowMaximized;
@@ -179,18 +182,6 @@ QMargins QGnomePlatformDecoration::margins(MarginsType marginsType) const
             return QMargins(tiledLeft ? 0 : SHADOWS_WIDTH, tiledTop ? 0 : SHADOWS_WIDTH, tiledRight ? 0 : SHADOWS_WIDTH, tiledBottom ? 0 : SHADOWS_WIDTH);
         }
     }
-#else
-QMargins QGnomePlatformDecoration::margins() const
-{
-    if ((window()->windowStates() & Qt::WindowMaximized)) {
-        return QMargins(0, TITLEBAR_HEIGHT, 0, 0);
-    }
-
-    return QMargins(WINDOW_BORDER_WIDTH, // Left
-                    TITLEBAR_HEIGHT + WINDOW_BORDER_WIDTH, // Top
-                    WINDOW_BORDER_WIDTH, // Right
-                    WINDOW_BORDER_WIDTH); // Bottom
-#endif
 }
 
 void QGnomePlatformDecoration::paint(QPaintDevice *device)

--- a/src/decoration/qgnomeplatformdecoration.cpp
+++ b/src/decoration/qgnomeplatformdecoration.cpp
@@ -372,7 +372,7 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // *                              *
     // ********************************
     QPainterPath borderRect;
-    if (!(window()->windowStates() & Qt::WindowMaximized)) {
+    if (!(waylandWindow()->windowStates() & Qt::WindowMaximized)) {
         borderRect.addRoundedRect(0, 0, surfaceRect.width(), margins().top() + 8, 10, 10);
         p.fillPath(borderRect.simplified(), borderColor);
     }
@@ -390,7 +390,7 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // *                              *
     // ********************************
     QPainterPath roundedRect;
-    if ((window()->windowStates() & Qt::WindowMaximized)) {
+    if ((waylandWindow()->windowStates() & Qt::WindowMaximized)) {
         roundedRect.addRect(0, 0, surfaceRect.width(), margins().top() + 8);
     } else {
         roundedRect
@@ -414,7 +414,7 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // *|                            |*
     // *------------------------------*
     // ********************************
-    if (!(window()->windowStates() & Qt::WindowMaximized)) {
+    if (!(waylandWindow()->windowStates() & Qt::WindowMaximized)) {
         QPainterPath borderPath;
         // Left
         borderPath.addRect(0, margins().top(), margins().left(), surfaceRect.height() - margins().top() - WINDOW_BORDER_WIDTH);
@@ -499,7 +499,7 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     if (GnomeSettings::getInstance().titlebarButtons().testFlag(GnomeSettings::getInstance().MaximizeButton)) {
         renderButton(&p,
                      maximizeButtonRect(),
-                     (window()->windowStates() & Qt::WindowMaximized) ? Adwaita::ButtonType::ButtonRestore : Adwaita::ButtonType::ButtonMaximize,
+                     (waylandWindow()->windowStates() & Qt::WindowMaximized) ? Adwaita::ButtonType::ButtonRestore : Adwaita::ButtonType::ButtonMaximize,
                      m_maximizeButtonHovered && active,
                      m_clicking == Button::Maximize || m_clicking == Button::Restore);
     }

--- a/src/decoration/qgnomeplatformdecoration.h
+++ b/src/decoration/qgnomeplatformdecoration.h
@@ -46,11 +46,7 @@ public:
     virtual ~QGnomePlatformDecoration() override = default;
 
 protected:
-#ifdef DECORATION_SHADOWS_SUPPORT // Qt 6.2.0+ or patched QtWayland
     QMargins margins(MarginsType marginsType = Full) const override;
-#else
-    QMargins margins() const override;
-#endif
     void paint(QPaintDevice *device) override;
     bool handleMouse(QWaylandInputDevice *inputDevice, const QPointF &local, const QPointF &global, Qt::MouseButtons b, Qt::KeyboardModifiers mods) override;
 #if QT_VERSION >= 0x060000


### PR DESCRIPTION
Build without `DECORATION_SHADOWS_SUPPORT` was broken (at least with Qt 5.15 from Fedora). It also required some changes to get it work correctly.

Also added "Use more updated window state values" patch that existed in Fedora repos until 0.9 version -- I think it could be still useful when building without shadows (espetially it could be used for [PR #116](https://github.com/FedoraQt/QGnomePlatform/pull/116) to gracefully disable shadows if not needed)