### PR TITLE
Fix regression in rendering titlebar on vanilla Qt

### DIFF
--- a/src/decoration/qgnomeplatformdecoration.cpp
+++ b/src/decoration/qgnomeplatformdecoration.cpp
@@ -195,14 +195,14 @@ QMargins QGnomePlatformDecoration::margins() const
 
 void QGnomePlatformDecoration::paint(QPaintDevice *device)
 {
-    Qt::WindowStates windowStates;
 #ifdef DECORATION_SHADOWS_SUPPORT // Qt 6.2.0+ or patched QtWayland
-    windowStates = waylandWindow()->windowStates();
+    const Qt::WindowStates windowStates = waylandWindow()->windowStates();
+    const bool active = windowStates & Qt::WindowActive;
 #else
-    windowStates = window()->windowStates();
+    const Qt::WindowStates windowStates = window()->windowStates();
+    const bool active = window()->handle()->isActive();
 #endif
 
-    const bool active = windowStates & Qt::WindowActive;
     const QRect surfaceRect = windowContentGeometry();
     const QColor borderColor = active ? m_borderColor : m_borderInactiveColor;
 
@@ -783,14 +783,14 @@ void QGnomePlatformDecoration::processMouseRight(QWaylandInputDevice *inputDevic
 
 void QGnomePlatformDecoration::renderButton(QPainter *painter, const QRectF &rect, Adwaita::ButtonType button, bool renderFrame, bool sunken)
 {
-    Qt::WindowStates windowStates;
 #ifdef DECORATION_SHADOWS_SUPPORT // Qt 6.2.0+ or patched QtWayland
-    windowStates = waylandWindow()->windowStates();
+    const Qt::WindowStates windowStates = waylandWindow()->windowStates();
+    const bool active = windowStates & Qt::WindowActive;
 #else
-    windowStates = window()->windowStates();
+    const Qt::WindowStates windowStates = window()->windowStates();
+    const bool active = window()->handle()->isActive();
 #endif
 
-    const bool active = windowStates & Qt::WindowActive;
     Adwaita::StyleOptions decorationButtonStyle(painter, QRect());
     decorationButtonStyle.setColor(active ? m_foregroundColor : m_foregroundInactiveColor);
 


### PR DESCRIPTION
Don't use `window()->windowStates()` for checking active window state on vanilla Qt5, this works only with `waylandWindow()` on Qt6 or with KDE's patchset for Qt5 (since commit [e532733](https://invent.kde.org/qt/qt/qtwayland/-/commit/e532733f7f4406d6b656c12cd107736dacd570e7) where `waylandWindow()->windowStates()` was introduced).

Fixes #125