### PR TITLE
Make border between window and decorations thinner

### DIFF
--- a/src/decoration/qgnomeplatformdecoration.cpp
+++ b/src/decoration/qgnomeplatformdecoration.cpp
@@ -67,6 +67,7 @@
 #define SHADOWS_WIDTH 10
 #define TITLEBAR_HEIGHT 37
 #define WINDOW_BORDER_WIDTH 1
+#define TITLEBAR_SEPARATOR_SIZE 0.5
 
 Q_DECL_IMPORT void qt_blurImage(QPainter *p, QImage &blurImage, qreal radius, bool quality, bool alphaOnly, int transposed = 0);
 
@@ -449,7 +450,10 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // ********************************
     p.save();
     p.setPen(borderColor);
-    p.drawLine(margins().left(), margins().top() - WINDOW_BORDER_WIDTH, surfaceRect.width() - margins().right(), margins().top() - WINDOW_BORDER_WIDTH);
+    p.drawLine(QLineF(margins().left(),
+                      margins().top() - TITLEBAR_SEPARATOR_SIZE,
+                      surfaceRect.width() - margins().right(),
+                      margins().top() - TITLEBAR_SEPARATOR_SIZE));
     p.restore();
 
     // Window title


### PR DESCRIPTION
It makes border exactly the same size as in GTK3.

Before:
![image](https://user-images.githubusercontent.com/6562863/209997629-335f4f52-fd91-422b-85cc-3bf774d7ff52.png)

After:
![image](https://user-images.githubusercontent.com/6562863/209997470-bcd66290-9aa4-48d4-a52c-6a5f3e50e118.png)
