### PR TITLE
Prevent window from losing focus while moving or resizing

### DIFF
--- a/src/decoration/qgnomeplatformdecoration.h
+++ b/src/decoration/qgnomeplatformdecoration.h
@@ -61,6 +61,9 @@ protected:
     handleTouch(QWaylandInputDevice *inputDevice, const QPointF &local, const QPointF &global, Qt::TouchPointState state, Qt::KeyboardModifiers mods) override;
 #endif
 
+protected slots:
+    void forceWindowActivation();
+
 private:
     QRect windowContentGeometry() const;
 


### PR DESCRIPTION
Experimental fix for nasty bug with losing window focus -- #115 or https://github.com/FedoraQt/adwaita-qt/issues/170

This is really a dirty hack, but it actually works. Only for Wayland.

One can test it using my [copr repo](https://copr.fedorainfracloud.org/coprs/polter/qt5/)