### PR TITLE
Missing ifdef for Gdk X11 extension

### DIFF
--- a/src/theme/qgtk3dialoghelpers.cpp
+++ b/src/theme/qgtk3dialoghelpers.cpp
@@ -51,7 +51,9 @@
 
 #undef signals
 #include <gdk/gdk.h>
+#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
+#endif
 #include <gtk/gtk.h>
 #include <pango/pango.h>
 


### PR DESCRIPTION
The usage of gdkx.h Classes are already inside an ifdef but the include is not.

this is the only place in the entire project that requires X11 extensions from Gtk3

This is only relevant if your someone like me who uses GTK3 without X11 extensions enabled. which causes a failure here as Gdkx.h doesn't exist on my system
