### PR TITLE
Implement reasonable icon themes fallbacks

### DIFF
--- a/src/common/gsettingshintprovider.cpp
+++ b/src/common/gsettingshintprovider.cpp
@@ -83,11 +83,11 @@ GSettingsHintProvider::GSettingsHintProvider(QObject *parent)
     loadCursorBlinkTime();
     loadCursorSize();
     loadCursorTheme();
-    loadIconTheme();
     loadFonts();
     loadStaticHints();
     loadTheme();
     loadTitlebar();
+    loadIconTheme();
 }
 
 GSettingsHintProvider::~GSettingsHintProvider()

--- a/src/common/portalhintprovider.cpp
+++ b/src/common/portalhintprovider.cpp
@@ -104,11 +104,11 @@ void PortalHintProvider::onSettingsReceived()
     loadCursorBlinkTime();
     loadCursorSize();
     loadCursorTheme();
-    loadIconTheme();
     loadFonts();
     loadStaticHints();
     loadTheme();
     loadTitlebar();
+    loadIconTheme();
 }
 void PortalHintProvider::settingChanged(const QString &group, const QString &key, const QDBusVariant &value)
 {


### PR DESCRIPTION
This makes QGnomePlatform also use 'breeze-dark' theme in case the user has dark theme.

Depends on: https://codereview.qt-project.org/c/qt/qtbase/+/476542
Fixes #103