### PR TITLE
Save margins instead of computing all four every time

### DIFF
--- a/src/decoration/qgnomeplatformdecoration.cpp
+++ b/src/decoration/qgnomeplatformdecoration.cpp
@@ -96,14 +96,15 @@ QGnomePlatformDecoration::QGnomePlatformDecoration()
 
 QRectF QGnomePlatformDecoration::closeButtonRect() const
 {
+    const QMargins marg = margins();
     if (GnomeSettings::getInstance().titlebarButtonPlacement() == GnomeSettings::getInstance().RightPlacement) {
-        return QRectF(windowContentGeometry().width() - BUTTON_WIDTH - (BUTTON_SPACING * 0) - BUTTON_MARGINS - margins().right(),
-                      (margins().top() - BUTTON_WIDTH + margins().bottom()) / 2,
+        return QRectF(windowContentGeometry().width() - BUTTON_WIDTH - (BUTTON_SPACING * 0) - BUTTON_MARGINS - marg.right(),
+                      (marg.top() - BUTTON_WIDTH + marg.bottom()) / 2,
                       BUTTON_WIDTH,
                       BUTTON_WIDTH);
     } else {
-        return QRectF(BUTTON_SPACING * 0 + BUTTON_MARGINS + margins().left(),
-                      (margins().top() - BUTTON_WIDTH + margins().bottom()) / 2,
+        return QRectF(BUTTON_SPACING * 0 + BUTTON_MARGINS + marg.left(),
+                      (marg.top() - BUTTON_WIDTH + marg.bottom()) / 2,
                       BUTTON_WIDTH,
                       BUTTON_WIDTH);
     }
@@ -111,14 +112,15 @@ QRectF QGnomePlatformDecoration::closeButtonRect() const
 
 QRectF QGnomePlatformDecoration::maximizeButtonRect() const
 {
+    const QMargins marg = margins();
     if (GnomeSettings::getInstance().titlebarButtonPlacement() == GnomeSettings::getInstance().RightPlacement) {
-        return QRectF(windowContentGeometry().width() - (BUTTON_WIDTH * 2) - (BUTTON_SPACING * 1) - BUTTON_MARGINS - margins().right(),
-                      (margins().top() - BUTTON_WIDTH + margins().bottom()) / 2,
+        return QRectF(windowContentGeometry().width() - (BUTTON_WIDTH * 2) - (BUTTON_SPACING * 1) - BUTTON_MARGINS - marg.right(),
+                      (marg.top() - BUTTON_WIDTH + marg.bottom()) / 2,
                       BUTTON_WIDTH,
                       BUTTON_WIDTH);
     } else {
-        return QRectF(BUTTON_WIDTH * 1 + (BUTTON_SPACING * 1) + BUTTON_MARGINS + margins().left(),
-                      (margins().top() - BUTTON_WIDTH + margins().bottom()) / 2,
+        return QRectF(BUTTON_WIDTH * 1 + (BUTTON_SPACING * 1) + BUTTON_MARGINS + marg.left(),
+                      (marg.top() - BUTTON_WIDTH + marg.bottom()) / 2,
                       BUTTON_WIDTH,
                       BUTTON_WIDTH);
     }
@@ -127,16 +129,16 @@ QRectF QGnomePlatformDecoration::maximizeButtonRect() const
 QRectF QGnomePlatformDecoration::minimizeButtonRect() const
 {
     const bool maximizeEnabled = GnomeSettings::getInstance().titlebarButtons().testFlag(GnomeSettings::getInstance().MaximizeButton);
-
+    const QMargins marg = margins();
     if (GnomeSettings::getInstance().titlebarButtonPlacement() == GnomeSettings::getInstance().RightPlacement) {
         return QRectF(windowContentGeometry().width() - BUTTON_WIDTH * (maximizeEnabled ? 3 : 2) - (BUTTON_SPACING * (maximizeEnabled ? 2 : 1)) - BUTTON_MARGINS
-                          - margins().right(),
-                      (margins().top() - BUTTON_WIDTH + margins().bottom()) / 2,
+                          - marg.right(),
+                      (marg.top() - BUTTON_WIDTH + marg.bottom()) / 2,
                       BUTTON_WIDTH,
                       BUTTON_WIDTH);
     } else {
-        return QRectF(BUTTON_WIDTH * (maximizeEnabled ? 2 : 1) + (BUTTON_SPACING * (maximizeEnabled ? 2 : 1)) + BUTTON_MARGINS + margins().left(),
-                      (margins().top() - BUTTON_WIDTH + margins().bottom()) / 2,
+        return QRectF(BUTTON_WIDTH * (maximizeEnabled ? 2 : 1) + (BUTTON_SPACING * (maximizeEnabled ? 2 : 1)) + BUTTON_MARGINS + marg.left(),
+                      (marg.top() - BUTTON_WIDTH + marg.bottom()) / 2,
                       BUTTON_WIDTH,
                       BUTTON_WIDTH);
     }
@@ -204,6 +206,7 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     const bool active = window()->handle()->isActive();
 #endif
 
+    const QMargins marg = margins();
     const QRect surfaceRect = windowContentGeometry();
     const QColor borderColor = active ? m_borderColor : m_borderInactiveColor;
 
@@ -273,10 +276,10 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
         }
 
         QRect clips[] = {
-            QRect(0, 0, surfaceRect.width(), margins().top()),
-            QRect(0, margins().top(), margins().left(), surfaceRect.height() - margins().top() - margins().bottom()),
-            QRect(0, surfaceRect.height() - margins().bottom(), surfaceRect.width(), margins().bottom()),
-            QRect(surfaceRect.width() - margins().right(), margins().top(), margins().right(), surfaceRect.height() - margins().top() - margins().bottom())};
+            QRect(0, 0, surfaceRect.width(), marg.top()),
+            QRect(0, marg.top(), marg.left(), surfaceRect.height() - marg.top() - marg.bottom()),
+            QRect(0, surfaceRect.height() - marg.bottom(), surfaceRect.width(), marg.bottom()),
+            QRect(surfaceRect.width() - marg.right(), marg.top(), marg.right(), surfaceRect.height() - marg.top() - marg.bottom())};
 
         for (int i = 0; i < 4; ++i) {
             p.save();
@@ -300,7 +303,7 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // ********************************
     QPainterPath borderRect;
     if (!(maximized || tiledLeft || tiledRight)) {
-        borderRect.addRoundedRect(SHADOWS_WIDTH, SHADOWS_WIDTH, surfaceRect.width() - (2 * SHADOWS_WIDTH), margins().top() + 8, 10, 10);
+        borderRect.addRoundedRect(SHADOWS_WIDTH, SHADOWS_WIDTH, surfaceRect.width() - (2 * SHADOWS_WIDTH), marg.top() + 8, 10, 10);
         p.fillPath(borderRect.simplified(), borderColor);
     }
 
@@ -318,12 +321,12 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // ********************************
     QPainterPath roundedRect;
     if (maximized || tiledRight || tiledLeft) {
-        roundedRect.addRect(margins().left(), margins().bottom(), surfaceRect.width() - margins().left() - margins().right(), margins().top() + 8);
+        roundedRect.addRect(marg.left(), marg.bottom(), surfaceRect.width() - marg.left() - marg.right(), marg.top() + 8);
     } else {
-        roundedRect.addRoundedRect(margins().left(), margins().bottom(), surfaceRect.width() - margins().left() - margins().right(), margins().top() + 8, 8, 8);
+        roundedRect.addRoundedRect(marg.left(), marg.bottom(), surfaceRect.width() - marg.left() - marg.right(), marg.top() + 8, 8, 8);
     }
 
-    QLinearGradient gradient(margins().left(), margins().top() + 6, margins().left(), 1);
+    QLinearGradient gradient(marg.left(), marg.top() + 6, marg.left(), 1);
     gradient.setColorAt(0, active ? m_backgroundColorStart : m_backgroundInactiveColor);
     gradient.setColorAt(1, active ? m_backgroundColorEnd : m_backgroundInactiveColor);
     p.fillPath(roundedRect.simplified(), gradient);
@@ -346,9 +349,9 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
         if (!tiledLeft) {
             // Assume tiled-left also means it will be tiled-top and tiled bottom
             borderPath.addRect(SHADOWS_WIDTH,
-                               tiledTop || tiledBottom ? 0 : margins().top(),
+                               tiledTop || tiledBottom ? 0 : marg.top(),
                                WINDOW_BORDER_WIDTH,
-                               tiledTop || tiledBottom ? surfaceRect.height() : surfaceRect.height() - margins().top() - SHADOWS_WIDTH - WINDOW_BORDER_WIDTH);
+                               tiledTop || tiledBottom ? surfaceRect.height() : surfaceRect.height() - marg.top() - SHADOWS_WIDTH - WINDOW_BORDER_WIDTH);
         }
         // Bottom
         if (!tiledBottom) {
@@ -359,10 +362,10 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
         }
         // Right
         if (!tiledRight) {
-            borderPath.addRect(surfaceRect.width() - margins().right(),
-                               tiledTop || tiledBottom ? 0 : margins().top(),
+            borderPath.addRect(surfaceRect.width() - marg.right(),
+                               tiledTop || tiledBottom ? 0 : marg.top(),
                                WINDOW_BORDER_WIDTH,
-                               tiledTop || tiledBottom ? surfaceRect.height() : surfaceRect.height() - margins().top() - SHADOWS_WIDTH - WINDOW_BORDER_WIDTH);
+                               tiledTop || tiledBottom ? surfaceRect.height() : surfaceRect.height() - marg.top() - SHADOWS_WIDTH - WINDOW_BORDER_WIDTH);
         }
         p.fillPath(borderPath, borderColor);
     }
@@ -381,7 +384,7 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // ********************************
     QPainterPath borderRect;
     if (!(windowStates & Qt::WindowMaximized)) {
-        borderRect.addRoundedRect(0, 0, surfaceRect.width(), margins().top() + 8, 10, 10);
+        borderRect.addRoundedRect(0, 0, surfaceRect.width(), marg.top() + 8, 10, 10);
         p.fillPath(borderRect.simplified(), borderColor);
     }
 
@@ -399,13 +402,13 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // ********************************
     QPainterPath roundedRect;
     if ((windowStates & Qt::WindowMaximized)) {
-        roundedRect.addRect(0, 0, surfaceRect.width(), margins().top() + 8);
+        roundedRect.addRect(0, 0, surfaceRect.width(), marg.top() + 8);
     } else {
         roundedRect
-            .addRoundedRect(WINDOW_BORDER_WIDTH, WINDOW_BORDER_WIDTH, surfaceRect.width() - margins().left() - margins().right(), margins().top() + 8, 8, 8);
+            .addRoundedRect(WINDOW_BORDER_WIDTH, WINDOW_BORDER_WIDTH, surfaceRect.width() - marg.left() - marg.right(), marg.top() + 8, 8, 8);
     }
 
-    QLinearGradient gradient(margins().left(), margins().top() + 6, margins().left(), 1);
+    QLinearGradient gradient(marg.left(), marg.top() + 6, marg.left(), 1);
     gradient.setColorAt(0, active ? m_backgroundColorStart : m_backgroundInactiveColor);
     gradient.setColorAt(1, active ? m_backgroundColorEnd : m_backgroundInactiveColor);
     p.fillPath(roundedRect.simplified(), gradient);
@@ -425,14 +428,14 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     if (!(windowStates & Qt::WindowMaximized)) {
         QPainterPath borderPath;
         // Left
-        borderPath.addRect(0, margins().top(), margins().left(), surfaceRect.height() - margins().top() - WINDOW_BORDER_WIDTH);
+        borderPath.addRect(0, marg.top(), marg.left(), surfaceRect.height() - marg.top() - WINDOW_BORDER_WIDTH);
         // Bottom
         borderPath.addRect(0, surfaceRect.height() - WINDOW_BORDER_WIDTH, surfaceRect.width(), WINDOW_BORDER_WIDTH);
         // Right
-        borderPath.addRect(surfaceRect.width() - margins().right(),
-                           margins().top(),
+        borderPath.addRect(surfaceRect.width() - marg.right(),
+                           marg.top(),
                            WINDOW_BORDER_WIDTH,
-                           surfaceRect.height() - margins().bottom() - margins().top());
+                           surfaceRect.height() - marg.bottom() - marg.top());
         p.fillPath(borderPath, borderColor);
     }
 #endif
@@ -450,10 +453,10 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // ********************************
     p.save();
     p.setPen(borderColor);
-    p.drawLine(QLineF(margins().left(),
-                      margins().top() - TITLEBAR_SEPARATOR_SIZE,
-                      surfaceRect.width() - margins().right(),
-                      margins().top() - TITLEBAR_SEPARATOR_SIZE));
+    p.drawLine(QLineF(marg.left(),
+                      marg.top() - TITLEBAR_SEPARATOR_SIZE,
+                      surfaceRect.width() - marg.right(),
+                      marg.top() - TITLEBAR_SEPARATOR_SIZE));
     p.restore();
 
     // Window title
@@ -469,7 +472,7 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
     // *------------------------------*
     // ********************************
 
-    const QRect top = QRect(margins().left(), margins().bottom(), surfaceRect.width(), margins().top() - margins().bottom());
+    const QRect top = QRect(marg.left(), marg.bottom(), surfaceRect.width(), marg.top() - marg.bottom());
     const QString windowTitleText = window()->title();
     if (!windowTitleText.isEmpty()) {
         if (m_windowTitle.text() != windowTitleText) {
@@ -479,11 +482,11 @@ void QGnomePlatformDecoration::paint(QPaintDevice *device)
 
         QRect titleBar = top;
         if (GnomeSettings::getInstance().titlebarButtonPlacement() == GnomeSettings::getInstance().RightPlacement) {
-            titleBar.setLeft(margins().left());
+            titleBar.setLeft(marg.left());
             titleBar.setRight(static_cast<int>(minimizeButtonRect().left()) - 8);
         } else {
             titleBar.setLeft(static_cast<int>(minimizeButtonRect().right()) + 8);
-            titleBar.setRight(surfaceRect.width() - margins().right());
+            titleBar.setRight(surfaceRect.width() - marg.right());
         }
 
         p.save();
@@ -563,20 +566,21 @@ bool QGnomePlatformDecoration::handleMouse(QWaylandInputDevice *inputDevice,
                                            Qt::KeyboardModifiers mods)
 {
     Q_UNUSED(global)
+    const QMargins marg = margins();
 
-    if (local.y() > margins().top()) {
+    if (local.y() > marg.top()) {
         updateButtonHoverState(Button::None);
     }
 
     // Figure out what area mouse is in
     QRect surfaceRect = windowContentGeometry();
-    if (local.y() <= surfaceRect.top() + margins().top()) {
+    if (local.y() <= surfaceRect.top() + marg.top()) {
         processMouseTop(inputDevice, local, b, mods);
-    } else if (local.y() > surfaceRect.bottom() - margins().bottom()) {
+    } else if (local.y() > surfaceRect.bottom() - marg.bottom()) {
         processMouseBottom(inputDevice, local, b, mods);
-    } else if (local.x() <= surfaceRect.left() + margins().left()) {
+    } else if (local.x() <= surfaceRect.left() + marg.left()) {
         processMouseLeft(inputDevice, local, b, mods);
-    } else if (local.x() > surfaceRect.right() - margins().right()) {
+    } else if (local.x() > surfaceRect.right() - marg.right()) {
         processMouseRight(inputDevice, local, b, mods);
     } else {
 #if QT_CONFIG(cursor)
@@ -681,18 +685,20 @@ void QGnomePlatformDecoration::processMouseTop(QWaylandInputDevice *inputDevice,
     QDateTime currentDateTime = QDateTime::currentDateTime();
     QRect surfaceRect = windowContentGeometry();
 
+    const QMargins marg = margins();
+
     if (!closeButtonRect().contains(local) && !maximizeButtonRect().contains(local) && !minimizeButtonRect().contains(local)) {
         updateButtonHoverState(Button::None);
     }
 
-    if (local.y() <= surfaceRect.top() + margins().bottom()) {
-        if (local.x() <= margins().left()) {
+    if (local.y() <= surfaceRect.top() + marg.bottom()) {
+        if (local.x() <= marg.left()) {
             // top left bit
 #if QT_CONFIG(cursor)
             waylandWindow()->setMouseCursor(inputDevice, Qt::SizeFDiagCursor);
 #endif
             startResize(inputDevice, Qt::TopEdge | Qt::LeftEdge, b);
-        } else if (local.x() > surfaceRect.right() - margins().left()) {
+        } else if (local.x() > surfaceRect.right() - marg.left()) {
             // top right bit
 #if QT_CONFIG(cursor)
             waylandWindow()->setMouseCursor(inputDevice, Qt::SizeBDiagCursor);
@@ -705,9 +711,9 @@ void QGnomePlatformDecoration::processMouseTop(QWaylandInputDevice *inputDevice,
 #endif
             startResize(inputDevice, Qt::TopEdge, b);
         }
-    } else if (local.x() <= surfaceRect.left() + margins().left()) {
+    } else if (local.x() <= surfaceRect.left() + marg.left()) {
         processMouseLeft(inputDevice, local, b, mods);
-    } else if (local.x() > surfaceRect.right() - margins().right()) {
+    } else if (local.x() > surfaceRect.right() - marg.right()) {
         processMouseRight(inputDevice, local, b, mods);
     } else if (closeButtonRect().contains(local)) {
         if (clickButton(b, Close)) {
@@ -744,13 +750,15 @@ void QGnomePlatformDecoration::processMouseTop(QWaylandInputDevice *inputDevice,
 void QGnomePlatformDecoration::processMouseBottom(QWaylandInputDevice *inputDevice, const QPointF &local, Qt::MouseButtons b, Qt::KeyboardModifiers mods)
 {
     Q_UNUSED(mods)
-    if (local.x() <= margins().left()) {
+    const QMargins marg = margins();
+    
+    if (local.x() <= marg.left()) {
         // bottom left bit
 #if QT_CONFIG(cursor)
         waylandWindow()->setMouseCursor(inputDevice, Qt::SizeBDiagCursor);
 #endif
         startResize(inputDevice, Qt::BottomEdge | Qt::LeftEdge, b);
-    } else if (local.x() > window()->width() + margins().right()) {
+    } else if (local.x() > window()->width() + marg.right()) {
         // bottom right bit
 #if QT_CONFIG(cursor)
         waylandWindow()->setMouseCursor(inputDevice, Qt::SizeFDiagCursor);


### PR DESCRIPTION
All four margins get computed every time we want to access one. Very straightforward change. It has little to no impact, but it costs nothing. Let me know if `marg` is a terrible name, I will change it.